### PR TITLE
chore: add Slack CLI support

### DIFF
--- a/.slack/.gitignore
+++ b/.slack/.gitignore
@@ -1,0 +1,2 @@
+apps.dev.json
+cache/

--- a/.slack/hooks.json
+++ b/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "python3 -m slack_cli_hooks.hooks.get_hooks"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ tooling, and resources created to help developers build and grow.
 
 ## Installation
 
-<details><summary><strong>Using Slack CLI</strong></summary>
+### Using Slack CLI
 
 Install the latest version of the Slack CLI for your operating system:
 
@@ -34,23 +34,18 @@ slack login
 #### Initializing the project
 
 ```sh
-slack create my-bolt-python-custom-step --template slack-samples/bolt-python-custom-step-template
-cd my-bolt-python-custom-step
+slack create bolt-python-custom-step --template slack-samples/bolt-python-custom-step-template
+cd bolt-python-custom-step
 ```
 
-#### Creating the Slack app
-
-Use the following command to add your new Slack app to your development workspace. Choose a "local" app environment for upcoming development:
+#### Running the app
 
 ```sh
-slack install
+slack run
 ```
 
-After the Slack app has been created you're all set to start developing!
-
-</details>
-
-<details><summary><strong>Using Terminal</strong></summary>
+<details>
+<summary><h3>Using Terminal</h3></summary>
 
 #### Create Your Slack App
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 slack-bolt==1.29.0
 pytest==9.1.1
 ruff==0.15.20
+slack-cli-hooks==0.3.0


### PR DESCRIPTION
This standardizes Slack CLI support for this sample so it can be created and run with the Slack CLI (`slack create` / `slack run`), matching the other CLI-enabled Bolt samples.

Adds (only the pieces this repo was missing):
- `.slack/hooks.json` — the CLI `get-hooks` config
- `.slack/.gitignore` — ignores `apps.dev.json` and `cache/` (local CLI state)
- the CLI hooks dependency (`@slack/cli-hooks` for JS/TS, `slack-cli-hooks==0.3.0` for Python)
- a `### Using Slack CLI` README section, with the existing manual flow preserved under `Using Terminal`

Opened as a **draft** for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)